### PR TITLE
Replace UCX cache polling thread by Dask worker plugin

### DIFF
--- a/pyblazing/pyblazing/apiv2/context.py
+++ b/pyblazing/pyblazing/apiv2/context.py
@@ -19,7 +19,7 @@ from pyblazing.apiv2.filesystem import FileSystem
 from pyblazing.apiv2 import DataType
 import asyncio
 from distributed.comm import listen
-from pyblazing.apiv2.comms import run_polling_thread, listen
+from pyblazing.apiv2.comms import PollingPlugin, listen
 import json
 import collections
 from pyhive import hive
@@ -1172,15 +1172,10 @@ class BlazingContext(object):
 
 
             
-            print("starting polling thread")
-            # Start polling thread in asyncio function on each worker
-            import threading
-            def polling_thread():
-                print("Starting thread")
-                t1 = threading.Thread(target=run_polling_thread)
-                t1.start()
-                get_worker().polling_thread = t1
-            self.dask_client.run(polling_thread, wait=True)
+            print("starting polling plugin")
+            # Register and start polling plugin on each Dask worker
+            self.polling_plugin = PollingPlugin()
+            self.dask_client.register_worker_plugin(self.polling_plugin)
 
             # Start listener on each worker to send received messages to router
             print("starting listeners")


### PR DESCRIPTION
As discussed, UCX-Py is not thread-safe, thus this PR suggests a periodic callback mechanism to use the Dask worker's thread to run all UCX communications in BlazingSQL.

Without this PR -- i.e., running multiple threads for UCX -- the notebook in https://github.com/felipeblazing/blazingsql/blob/feature/adding-caches-for-ucx/notebooks/ucx_comms_test.ipynb always deadlocks for large enough sizes in my experiments, where large enough means `np.arange(41720, dtype="float64")`, tested in a DGX-1 with 2, 4 and 8 GPUs all deadlock in the outer join. With this PR there's _some_ improvement: it seems to always work for 2 GPUs, with 4 GPUs the first run of the outer join has always succeeded but it may fail after a few more runs (for me it has completed 5-6 times in a row before deadlocking), and with 8 GPUs I was able to get the outer join to run a couple of times successfully too, but it deadlocks more often than not.