### PR TITLE
Fix more UCX data races

### DIFF
--- a/engine/src/communication/CommunicationInterface/bufferTransport.cpp
+++ b/engine/src/communication/CommunicationInterface/bufferTransport.cpp
@@ -178,11 +178,13 @@ void buffer_transport::send(const char * buffer, size_t buffer_size){
 
 
 void buffer_transport::increment_frame_transmission() {
+	std::unique_lock<std::mutex> lock(mutex);
 	transmitted_frames++;
 	completion_condition_variable.notify_all();
 }
 
 void buffer_transport::increment_begin_transmission() {
+	std::unique_lock<std::mutex> lock(mutex);
 	transmitted_begin_frames++;
 	completion_condition_variable.notify_all();
 }

--- a/engine/src/communication/CommunicationInterface/messageListener.cpp
+++ b/engine/src/communication/CommunicationInterface/messageListener.cpp
@@ -25,6 +25,7 @@ void poll_for_frames(std::shared_ptr<message_receiver> receiver,
 		blazing_ucp_tag message_tag = *reinterpret_cast<blazing_ucp_tag *>(&tag);
 
 		if (receiver->num_buffers() == 0) {
+            ucx_message_listener::get_instance()->remove_receiver(tag);
 			receiver->finish();
 			return;
 		}
@@ -80,13 +81,13 @@ void poll_for_frames(std::shared_ptr<message_receiver> receiver,
 }
 
 
-void recv_begin_callback_c(std::shared_ptr<ucp_tag_recv_info_t> info, std::vector<char> data_buffer, size_t request_size, std::shared_ptr<ral::cache::CacheMachine> input_cache) {
+void recv_begin_callback_c(std::shared_ptr<ucp_tag_recv_info_t> info, std::shared_ptr<std::vector<char> > data_buffer, size_t request_size, std::shared_ptr<ral::cache::CacheMachine> input_cache) {
 
 	auto message_listener = ucx_message_listener::get_instance();
 
-	auto fwd = message_listener->get_pool().push([&message_listener, info, data_buffer{std::move(data_buffer)}, request_size, input_cache](int /*thread_id*/) {
-		
-		auto receiver = std::make_shared<message_receiver>(message_listener->get_node_map(), data_buffer, input_cache);
+   auto fwd = message_listener->get_pool().push([&message_listener, info, data_buffer, request_size, input_cache](int /*thread_id*/) {
+
+   auto receiver = std::make_shared<message_receiver>(message_listener->get_node_map(), *data_buffer, input_cache);
 
 		message_listener->add_receiver(info->sender_tag, receiver);
 
@@ -221,10 +222,10 @@ void ucx_message_listener::poll_begin_message_tag(bool running_from_unit_test){
 					}while(message_tag == nullptr);
 
 						char * request = new char[_request_size];
-						std::vector<char> data_buffer(info_tag->length);
+						auto data_buffer = std::make_shared<std::vector<char>>(std::vector<char>(info_tag->length));
 						
 						auto status = ucp_tag_recv_nbr(ucp_worker,
-							data_buffer.data(),
+							data_buffer->data(),
 							info_tag->length,
 							ucp_dt_make_contig(1),
 							info_tag->sender_tag,
@@ -233,13 +234,13 @@ void ucx_message_listener::poll_begin_message_tag(bool running_from_unit_test){
 						status = ucp_request_check_status(request + _request_size);
 						if (!UCS_STATUS_IS_ERR(status)) {
 							if(status == UCS_OK){
-								recv_begin_callback_c(info_tag, std::move(data_buffer), _request_size, input_cache);
+								recv_begin_callback_c(info_tag, data_buffer, _request_size, input_cache);
 								delete request;
 							}else{
 								ucp_progress_manager::get_instance()->add_recv_request(
 									request, 
-									[info_tag, data_buffer{std::move(data_buffer)}, request_size=_request_size, input_message_cache=input_cache](){ 
-										recv_begin_callback_c(info_tag, std::move(data_buffer), request_size, input_message_cache); }
+									[info_tag, data_buffer=data_buffer, request_size=_request_size, input_message_cache=input_cache]() { 
+										recv_begin_callback_c(info_tag, data_buffer, request_size, input_message_cache); }
 									,status);
 							}
 						} else {
@@ -275,7 +276,9 @@ std::shared_ptr<message_receiver> ucx_message_listener::get_receiver(ucp_tag_t t
 void ucx_message_listener::remove_receiver(ucp_tag_t tag){
 	std::lock_guard<std::mutex> lock(this->receiver_mutex);
 	if(tag_to_receiver.find(tag) != tag_to_receiver.end()){
-		
+
+        #if 0
+        // send acknowledgment, currently not used
 		auto receiver = tag_to_receiver[tag];
 		reinterpret_cast<blazing_ucp_tag *>(&tag)->frame_id = 0xFFFF;
 		char * buffer = new char[40];
@@ -291,14 +294,14 @@ void ucx_message_listener::remove_receiver(ucp_tag_t tag){
                                             tag,
                                             request + _request_size);
 		
-		tag_to_receiver.erase(tag);
 		if ((status >= UCS_OK)) {
 			//no callback needed for this
-			ucp_progress_manager::get_instance()->add_send_request(request, [](){  },status);
+			ucp_progress_manager::get_instance()->add_send_request(request, [buffer](){delete buffer; },status);
 		} else {
 			throw std::runtime_error("Immediate Communication error in send_impl.");
 		}
-
+        #endif
+		tag_to_receiver.erase(tag);
     }
         
 

--- a/engine/src/communication/CommunicationInterface/messageReceiver.hpp
+++ b/engine/src/communication/CommunicationInterface/messageReceiver.hpp
@@ -59,7 +59,7 @@ public:
   * @param output_cache The destination for the message being received. It is either a specific cache inbetween
   *                     two kernels or it is intended for the general input cache using a mesage_id
   */
-  message_receiver(const std::map<std::string, comm::node>& nodes, const std::vector<char> & buffer, std::shared_ptr<ral::cache::CacheMachine> input_cache);
+  message_receiver(const std::map<std::string, comm::node>& nodes, const std::vector<char>& buffer, std::shared_ptr<ral::cache::CacheMachine> input_cache);
   virtual ~message_receiver(){}
 
   size_t buffer_size(u_int16_t index);

--- a/engine/src/communication/CommunicationInterface/protocols.cpp
+++ b/engine/src/communication/CommunicationInterface/protocols.cpp
@@ -274,7 +274,6 @@ void ucx_buffer_transport::send_begin_transmission() {
     try {
         std::shared_ptr<std::vector<char>> buffer_to_send = std::make_shared<std::vector<char>>(detail::serialize_metadata_and_transports_and_buffer_sizes(metadata, column_transports, chunked_column_infos, buffer_sizes));
 
-        std::vector<char *> requests(destinations.size());
         int i = 0;
         for(auto const & node : destinations) {
             char * request = new char[_request_size];


### PR DESCRIPTION
In particular, store receive buffers for metadata in a shared pointer to avoid checking inconsistent copies in the progress loop

Going forward,  we might want to use the same pinned_buffer allocation for metadata as for the chunked dataframes